### PR TITLE
Update drupal.js

### DIFF
--- a/lib/drupal.js
+++ b/lib/drupal.js
@@ -162,6 +162,9 @@ Drupal.prototype.systemConnect = function (success, failure) {
     xhr.open("POST", url);
     xhr = this.setupCredentials(xhr);
     xhr.setRequestHeader("Accept", "application/json");
+    
+    // required for Titanium Mobile, maybe others?
+	xhr.setRequestHeader('Content-Type','application/json; charset=utf-8');
 
     // if session exists, token will be required
     var token = Settings.getString(this.settingsPrefix + "X-CSRF-Token");


### PR DESCRIPTION
Without setting Content-Type for systemConnect, returns 406 "Unsupported request content type application/x-www-form-urlencoded" error when using with Titanium Mobile and Services 3.7.
